### PR TITLE
Add `WORD` motions. Fixes #19. Fixes #24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ More useful word motions for Vim
 
 [![Build Status](https://travis-ci.org/chaoren/vim-wordmotion.svg?branch=master)](https://travis-ci.org/chaoren/vim-wordmotion)
 
-Under Vim's definition of a `word`:
+This is one word under Vim's definition:
 
 ```
 CamelCaseACRONYMWords_underscore1234
@@ -12,7 +12,7 @@ e--------------------------------->e
 b<---------------------------------b
 ```
 
-With this plugin:
+With this plugin, this becomes six words:
 
 ```
 CamelCaseACRONYMWords_underscore1234
@@ -23,6 +23,8 @@ b<---b<--b<-----b<----b<--------b<-b
 
 `word` definitions
 ==================
+
+A `word` (lowercase) is any of the following:
 
 | `word`               | Example               |
 |:---------------------|:----------------------|
@@ -36,20 +38,23 @@ b<---b<--b<-----b<----b<--------b<-b
 | Regular numbers      | `[1234] [5678]`       |
 | Other characters     | `[~!@#$]`             |
 
+A `WORD` (uppercase) is any sequence of non-space characters separated by
+spaces.
+
 Customization
 =============
 
-The default word motion mappings are as follows:
+Default `word`/`WORD` mappings:
 
-| Mode  | Mapping      |
-|:-----:|:------------:|
-| `nxo` | `w`          |
-| `nxo` | `b`          |
-| `nxo` | `e`          |
-| `nxo` | `ge`         |
-| `xo`  | `aw`         |
-| `xo`  | `iw`         |
-| `c`   | `<C-R><C-W>` |
+| Mode  | Mapping                   |
+|:-----:|:-------------------------:|
+| `nxo` | `w`/`W`                   |
+| `nxo` | `b`/`B`                   |
+| `nxo` | `e`/`E`                   |
+| `nxo` | `ge`/`gE`                 |
+| `xo`  | `aw`/`aW`                 |
+| `xo`  | `iw`/`iW`                 |
+| `c`   | `<C-R><C-W>`/`<C-R><C-A>` |
 
 Use `g:wordmotion_prefix` to apply a common prefix to each of the default word
 motion mappings.  
@@ -57,7 +62,8 @@ E.g.,
 ```
 let g:wordmotion_prefix = '<Leader>'
 ```
-NOTE: does not apply to the command line mode `<C-R><C-W>` mapping.
+NOTE: does not apply to the command line mode `<C-R><C-W>` and `<C-R><C-A>`
+mappings.
 
 Use `g:wordmotion_mappings` to individually replace the default word motion
 mappings.  
@@ -132,11 +138,8 @@ do this:
 ```
 nmap dw de
 nmap cw ce
-```
-If you want to also remove the special case behavior from `dW` and `cW`, as this
-plugin does with `dw` and `cw`, you can do this:
-```
-onoremap W :<C-U>normal! vWh<CR>
+nmap dW dE
+nmap cW cE
 ```
 
 Related

--- a/doc/wordmotion.txt
+++ b/doc/wordmotion.txt
@@ -14,8 +14,7 @@ With this plugin, this becomes six words:
 <
 WORDS						*wordmotion-words*
 
-A word is any of the following separated with spaces
-(<Space>, <Tab>, <EOL>, `_`, etc):
+A `word` is any of the following:
 
 - An uppercase letter followed by one or more lowercase letters
 - One or more uppercase letters that does not immediately precede
@@ -29,42 +28,77 @@ A word is any of the following separated with spaces
 - One or more of other characters
 - An empty line
 
+A `WORD` is any sequence of non-space characters separated by spaces.
+
 MAPPINGS					*wordmotion-mappings*
 
 						*wordmotion-w*
-{prefix}w		[count] words forward. |exclusive| motion.
+{prefix}w		[count] `word`s forward. |exclusive| motion.
 
 						*wordmotion-e*
-{prefix}e		Forward to the end of word [count] |inclusive|.
+{prefix}e		Forward to the end of `word` [count] |inclusive|.
 			Does not stop in an empty line.
 
 						*wordmotion-b*
-{prefix}b		[count] words backward. |exclusive| motion.
+{prefix}b		[count] `word`s backward. |exclusive| motion.
 
 						*wordmotion-ge*
-{prefix}ge		Backward to the end of word [count] |inclusive|.
+{prefix}ge		Backward to the end of `word` [count] |inclusive|.
 
 						*wordmotion-aw*
-a{prefix}w		"a word", select [count] words (see |wordmotion-word|).
+a{prefix}w		"a `word`", select [count] `word`s (see |wordmotion-word|).
 			Leading or trailing white space is included, but not
 			counted.
 			When used in Visual linewise mode "aw" switches to
 			Visual characterwise mode.
 
 						*wordmotion-iw*
-i{prefix}w		"inner word", select [count] words
+i{prefix}w		"inner `word`", select [count] `word`s
 			(see |wordmotion-word|).
-			White space between words is counted too.
+			White space between `word`s is counted too.
 			When used in Visual linewise mode "iw" switches to
 			Visual characterwise mode.
 
-						*wordmotion-<C-R>_<C-W>*
-<C-R><C-W>		Insert the word under the cursor in Cmdline mode
+						*wordmotion-c_<C-R>_<C-W>*
+CTRL-R CTRL-W		Insert the `word` under the cursor
+			(see |wordmotion-word|).
+
+						*wordmotion-W*
+{prefix}W		[count] `WORD`s forward. |exclusive| motion.
+
+						*wordmotion-E*
+{prefix}E		Forward to the end of `WORD` [count] |inclusive|.
+			Does not stop in an empty line.
+
+						*wordmotion-B*
+{prefix}B		[count] `WORD`s backward. |exclusive| motion.
+
+						*wordmotion-gE*
+{prefix}gE		Backward to the end of `WORD` [count] |inclusive|.
+
+						*wordmotion-aW*
+a{prefix}W		"a `WORD`", select [count] `WORD`s (see |wordmotion-word|).
+			Leading or trailing white space is included, but not
+			counted.
+			When used in Visual linewise mode "aW" switches to
+			Visual characterwise mode.
+
+						*wordmotion-iW*
+i{prefix}W		"inner `WORD`", select [count] `WORD`s
+			(see |wordmotion-word|).
+			White space between `WORD`s is counted too.
+			When used in Visual linewise mode "iW" switches to
+			Visual characterwise mode.
+
+						*wordmotion-c_<C-R>_<C-A>*
+<C-R><C-A>		Insert the `WORD` under the cursor
 			(see |wordmotion-word|).
 
 CUSTOMIZATION					*wordmotion-customization*
 
-The default word motion mappings are `w`, `b`, `e`, `ge`, `aw`, and `iw`.
+Default `word` mappings are `w`, `b`, `e`, `ge`, `aw`, `iw`, and `<C-R><C-W>`.
+
+Default `WORD` mappings are `W`, `B`, `E`, `gE`, `aW`, `iW`, and `<C-R><C-A>`.
 
 						*g:wordmotion_prefix*
 Use |g:wordmotion_prefix| to apply a common prefix to each of the default word
@@ -73,7 +107,8 @@ E.g.,
 >
 	let g:wordmotion_prefix = '<Leader>'
 <
-NOTE: does not apply to the command line mode `<C-R><C-W>` mapping.
+NOTE: does not apply to the command line mode `<C-R><C-W>` and `<C-R><C-A>`
+mappings.
 
 						*g:wordmotion_mappings*
 Use |g:wordmotion_mappings| to individually replace the default word motion
@@ -148,11 +183,8 @@ do this:
 >
 	nmap dw de
 	nmap cw ce
-<
-If you want to also remove the special case behavior from `dW` and `cW`, as this
-plugin does with `dw` and `cw`, you can do this:
->
-	onoremap W :<C-U>normal! vWh<CR>
+	nmap dW dE
+	nmap cW cE
 <
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/tests/crcw.vader
+++ b/tests/crcw.vader
@@ -16,6 +16,12 @@ Do (s/<cword>/changed/ at [s]ome):
 Expect (ChangedText):
   This is changedText
 
+Do (s/<cWORD>/changed/ at [s]ome):
+  2w:s/\<C-R>\<C-A>/changed/\<CR>
+
+Expect (Changed):
+  This is changed
+
 Given (Some text):
   This is some text
 

--- a/tests/extra_motions.vader
+++ b/tests/extra_motions.vader
@@ -25,6 +25,28 @@ Execute (Move by e and then ge):
     normal ge
   endfor
 
+Execute (Move by W and then B):
+  let expected = split('CuLDc0aesdet0iuledma0.', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal W
+  endfor
+  for current in reverse(expected)
+    AssertEqual current, getline('.')[col('.')-1]
+    normal B
+  endfor
+
+Execute (Move by E and then gE):
+  let expected = split('Cs4m,r0g,dodr1tteteaa.', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal E
+  endfor
+  for current in reverse(expected)
+    AssertEqual current, getline('.')[col('.')-1]
+    normal gE
+  endfor
+
 Given (CamelCaseACRONYMWords_underscore1234):
   CamelCaseACRONYMWords_underscore1234
 

--- a/tests/mappings.vader
+++ b/tests/mappings.vader
@@ -1,5 +1,5 @@
 Execute (Check default mappings):
-  let maps = [ 'iw', 'aw' ]
+  let maps = [ 'iw', 'aw', 'iW', 'aW' ]
   for map in maps
     Assert hasmapto('AOrInnerWordMotion', 'x')
     execute 'xunmap' map
@@ -7,7 +7,7 @@ Execute (Check default mappings):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('AOrInnerWordMotion', 'xo')
-  let maps = [ 'w', 'e', 'b', 'ge' ]
+  let maps = [ 'w', 'e', 'b', 'ge', 'W', 'E', 'B', 'gE' ]
   for map in maps
     Assert hasmapto('WordMotion', 'n')
     execute 'nunmap' map
@@ -17,8 +17,11 @@ Execute (Check default mappings):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('WordMotion', 'nxo')
-  Assert hasmapto('GetCurrentWord', 'c')
-  execute 'cunmap' '<C-R><C-W>'
+  let maps = [ '<C-R><C-W>', '<C-R><C-A>' ]
+  for map in maps
+    Assert hasmapto('GetCurrentWord', 'c')
+    execute 'cunmap' map
+  endfor
   Assert !hasmapto('GetCurrentWord', 'c')
 
 Execute (Check mappings with prefix):
@@ -26,7 +29,7 @@ Execute (Check mappings with prefix):
   unlet! g:wordmotion_mappings
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
-  let maps = [ 'i<Leader>w', 'a<Leader>w' ]
+  let maps = [ 'i<Leader>w', 'a<Leader>w', 'i<Leader>W', 'a<Leader>W' ]
   for map in maps
     Assert hasmapto('AOrInnerWordMotion', 'x')
     execute 'xunmap' map
@@ -34,7 +37,10 @@ Execute (Check mappings with prefix):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('AOrInnerWordMotion', 'xo')
-  let maps = [ '<Leader>w', '<Leader>e', '<Leader>b', '<Leader>ge' ]
+  let maps = [
+  \ '<Leader>w', '<Leader>e', '<Leader>b', '<Leader>ge',
+  \ '<Leader>W', '<Leader>E', '<Leader>B', '<Leader>gE',
+  \ ]
   for map in maps
     Assert hasmapto('WordMotion', 'n')
     execute 'nunmap' map
@@ -44,8 +50,11 @@ Execute (Check mappings with prefix):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('WordMotion', 'nxo')
-  Assert hasmapto('GetCurrentWord', 'c')
-  execute 'cunmap' '<C-R><C-W>'
+  let maps = [ '<C-R><C-W>', '<C-R><C-A>' ]
+  for map in maps
+    Assert hasmapto('GetCurrentWord', 'c')
+    execute 'cunmap' map
+  endfor
   Assert !hasmapto('GetCurrentWord', 'c')
 
 Execute (Check custom mappings):
@@ -58,10 +67,17 @@ Execute (Check custom mappings):
   \ 'iw' : 'i<M-w>',
   \ 'aw' : 'a<M-w>',
   \ '<C-R><C-W>' : '<C-R><M-w>',
+  \ 'W' : '<M-W>',
+  \ 'E' : '<M-E>',
+  \ 'B' : '<M-B>',
+  \ 'gE' : 'g<M-E>',
+  \ 'iW' : 'i<M-W>',
+  \ 'aW' : 'a<M-W>',
+  \ '<C-R><C-A>' : '<C-R><M-a>',
   \ }
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
-  let maps = [ 'i<M-w>', 'a<M-w>' ]
+  let maps = [ 'i<M-w>', 'a<M-w>', 'i<M-W>', 'a<M-W>' ]
   for map in maps
     Assert hasmapto('AOrInnerWordMotion', 'x')
     execute 'xunmap' map
@@ -69,7 +85,10 @@ Execute (Check custom mappings):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('AOrInnerWordMotion', 'xo')
-  let maps = [ '<M-w>', '<M-e>', '<M-b>', 'g<M-e>' ]
+  let maps = [
+  \ '<M-w>', '<M-e>', '<M-b>', 'g<M-e>',
+  \ '<M-W>', '<M-E>', '<M-B>', 'g<M-E>',
+  \ ]
   for map in maps
     Assert hasmapto('WordMotion', 'n')
     execute 'nunmap' map
@@ -79,20 +98,24 @@ Execute (Check custom mappings):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('WordMotion', 'nxo')
-  Assert hasmapto('GetCurrentWord', 'c')
-  execute 'cunmap' '<C-R><M-w>'
+  let maps = [ '<C-R><M-w>', '<C-R><M-a>' ]
+  for map in maps
+    Assert hasmapto('GetCurrentWord', 'c')
+    execute 'cunmap' map
+  endfor
   Assert !hasmapto('GetCurrentWord', 'c')
 
 Execute (Check mixed custom mappings with prefix):
   let g:wordmotion_prefix = ','
   let g:wordmotion_mappings = {
   \ 'e' : '<Plug>WordmotionE',
-  \ 'b' : '<Plug>WordmotionB',
+  \ 'B' : '<Plug>WordmotionB',
   \ 'iw' : '<Plug>WordmotionIW',
+  \ 'aW' : '<Plug>WordmotionAW',
   \ }
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
-  let maps = [ '<Plug>WordmotionIW', 'a,w' ]
+  let maps = [ '<Plug>WordmotionIW', 'a,w', 'i,W', '<Plug>WordmotionAW']
   for map in maps
     Assert hasmapto('AOrInnerWordMotion', 'x')
     execute 'xunmap' map
@@ -100,7 +123,10 @@ Execute (Check mixed custom mappings with prefix):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('AOrInnerWordMotion', 'xo')
-  let maps = [ ',w', '<Plug>WordmotionE', '<Plug>WordmotionB', ',ge' ]
+  let maps = [
+  \ ',w', '<Plug>WordmotionE', ',b', ',ge',
+  \ ',W', ',E', '<Plug>WordmotionB', ',gE',
+  \ ]
   for map in maps
     Assert hasmapto('WordMotion', 'n')
     execute 'nunmap' map
@@ -110,8 +136,11 @@ Execute (Check mixed custom mappings with prefix):
     execute 'ounmap' map
   endfor
   Assert !hasmapto('WordMotion', 'nxo')
-  Assert hasmapto('GetCurrentWord', 'c')
-  execute 'cunmap' '<C-R><C-W>'
+  let maps = [ '<C-R><C-W>', '<C-R><C-A>' ]
+  for map in maps
+    Assert hasmapto('GetCurrentWord', 'c')
+    execute 'cunmap' map
+  endfor
   Assert !hasmapto('GetCurrentWord', 'c')
 
 Execute (Check no mappings):
@@ -124,6 +153,13 @@ Execute (Check no mappings):
   \ 'iw' : '',
   \ 'aw' : '',
   \ '<C-R><C-W>' : '',
+  \ 'W' : '',
+  \ 'E' : '',
+  \ 'B' : '',
+  \ 'gE' : '',
+  \ 'iW' : '',
+  \ 'aW' : '',
+  \ '<C-R><C-A>' : '',
   \ }
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
@@ -140,6 +176,13 @@ Execute (Check no mappings even with prefix):
   \ 'iw' : '',
   \ 'aw' : '',
   \ '<C-R><C-W>' : '',
+  \ 'W' : '',
+  \ 'E' : '',
+  \ 'B' : '',
+  \ 'gE' : '',
+  \ 'iW' : '',
+  \ 'aW' : '',
+  \ '<C-R><C-A>' : '',
   \ }
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim

--- a/tests/reload.vader
+++ b/tests/reload.vader
@@ -14,6 +14,13 @@ Execute (Check removed mappings after reload):
   \ 'iw' : '',
   \ 'aw' : '',
   \ '<C-R><C-W>' : '',
+  \ 'W' : '',
+  \ 'E' : '',
+  \ 'B' : '',
+  \ 'gE' : '',
+  \ 'iW' : '',
+  \ 'aW' : '',
+  \ '<C-R><C-A>' : '',
   \ }
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim

--- a/tests/spaces.vader
+++ b/tests/spaces.vader
@@ -29,6 +29,28 @@ Execute (Move by e and then ge):
     normal ge
   endfor
 
+Execute (Move by W and then B):
+  let expected = split('Lidsacaesdetiuledma.', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal W
+  endfor
+  for current in reverse(expected)
+    AssertEqual current, getline('.')[col('.')-1]
+    normal B
+  endfor
+
+Execute (Move by E and then gE):
+  let expected = split('Lmmrt,rg,dodrttetea.', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal E
+  endfor
+  for current in reverse(expected)
+    AssertEqual current, getline('.')[col('.')-1]
+    normal gE
+  endfor
+
 Execute (Set spaces to '_-.'):
   let g:wordmotion_spaces = '_-.'
   unlet! g:loaded_wordmotion
@@ -58,6 +80,28 @@ Execute (Move by e and then ge):
   for current in reverse(copy(expected))
     AssertEqual current, getline('.')[col('.')-1]
     normal ge
+  endfor
+
+Execute (Move by W and then B):
+  let expected = split('Lidsacaesdetiuledma!', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal W
+  endfor
+  for current in reverse(copy(expected))
+    AssertEqual current, getline('.')[col('.')-1]
+    normal B
+  endfor
+
+Execute (Move by E and then gE):
+  let expected = split('Lmmrt,rg,dodrtteteaa!', '\zs')
+  for current in expected
+    AssertEqual current, getline('.')[col('.')-1]
+    normal E
+  endfor
+  for current in reverse(copy(expected))
+    AssertEqual current, getline('.')[col('.')-1]
+    normal gE
   endfor
 
 Execute (Reset plugin for further tests):


### PR DESCRIPTION
Same as regular `W`, `B`, `E`, `gE`, except it also respects
`g:wordmotion_spaces`.