### PR TITLE
Allow configuring extra spaces separately by mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ foo_bar-baz.qux
 w-->w-->w-->w>w
 ```
 
+Use `g:Wordmotion_Spaces` (defaults to whatever `g:wordmotion_spaces` is) to
+designate extra space characters when in 'WORD' mode. Setting this
+separately is useful in snake- or kebab-case languages where you want `w`
+and `b` to move by words (treating `_` or `-` as spaces), but `W` and `B` to
+move by entire tokens (ignoring the extra spaces defined for `w` and `b`).
+
 All options can be applied dynamically by reloading the plugin.  
 E.g., to disable the `w` mapping:
 ```

--- a/doc/wordmotion.txt
+++ b/doc/wordmotion.txt
@@ -141,6 +141,13 @@ will produce the following result:
 	foo_bar-baz.qux
 	^   ^   ^   ^
 <
+						*g:Wordmotion_Spaces*
+Use |g:Wordmotion_Spaces| (defaults to whatever 'g:wordmotion_spaces' is) to
+designate extra space characters when in 'WORD' mode. Setting this
+separately is useful in snake- or kebab-case languages where you want `w`
+and `b` to move by words (treating '_' or '-' as spaces), but `W` and `B` to
+move by entire tokens (ignoring the extra spaces defined for `w` and `b`).
+
 						*wordmotion-reload*
 All options can be applied dynamically by reloading the plugin.
 E.g., to disable the `w` mapping:

--- a/plugin/wordmotion.vim
+++ b/plugin/wordmotion.vim
@@ -6,6 +6,7 @@ let g:loaded_wordmotion = v:true
 let s:prefix = get(g:, 'wordmotion_prefix', '')
 let s:mappings = get(g:, 'wordmotion_mappings', { })
 let s:spaces = get(g:, 'wordmotion_spaces', '_')
+let s:Spaces = get(g:, 'Wordmotion_Spaces', '_')
 
 let s:flags = { 'w' : '', 'e' : 'e', 'b' : 'b', 'ge' : 'be' }
 let s:uppercases = [ 'W', 'E', 'B', 'gE', 'aW', 'iW', '<C-R><C-A>' ]
@@ -81,7 +82,9 @@ endfor " }}}
 " '-' in the middle will turn into a range, move it to the back.
 let s:spaces = substitute(s:spaces, '-\(.*\)$', '\1-', '')
 let s:s = '[[:space:]' . s:spaces . ']'
-let s:S = '[^[:space:]' . s:spaces . ']'
+
+let s:Spaces = substitute(s:Spaces, '-\(.*\)$', '\1-', '')
+let s:S = '[^[:space:]' . s:Spaces . ']'
 
 function! s:BuildWordPattern() abort " {{{
 	" [:alnum:] and [:alpha:] are ASCII only

--- a/tests/spaces.vader
+++ b/tests/spaces.vader
@@ -1,5 +1,6 @@
 Execute (Set spaces to '-'):
   let g:wordmotion_spaces = '-'
+  let g:Wordmotion_Spaces = '-'
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
 
@@ -53,6 +54,7 @@ Execute (Move by E and then gE):
 
 Execute (Set spaces to '_-.'):
   let g:wordmotion_spaces = '_-.'
+  let g:Wordmotion_Spaces = '_-.'
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim
 
@@ -106,5 +108,6 @@ Execute (Move by E and then gE):
 
 Execute (Reset plugin for further tests):
   unlet! g:wordmotion_spaces
+  unlet! g:Wordmotion_Spaces
   unlet! g:loaded_wordmotion
   runtime plugin/wordmotion.vim


### PR DESCRIPTION
Hi there! 

I hope you don't mind my creating a PR without talking it through with you first, but I figured this is the best way to explain what I'm getting at, and worst-case, you can just close it, no hard feelings. :)

The problem I'm trying to solve is that when I'm working in a snake- or kebab-case language (usually Python,) what I really want from this plugin is for `w` and `b` to move around by words within the tokens. and `W` and `B` to jump by entire tokens. To work well, this really needs the two modes to have separate lists of characters to treat as spaces (`g:wordmotion_spaces`), so that is what this PR allows.

Basically, it adds a new config value (`g:Wordmotion_Spaces`) which defines the extra space characters in `WORD` mode. It defaults to whatever the user has `g:wordmotion_spaces` set to, including the default, but allows people like me to fine-tune different behaviours in the two modes.

I modified the test set-up, so no previously-passing ones fail, but I'm not much of an expert in Vader, so I didn't add new tests to test behaviour when the two values are different.

I also made a jab at updating the docs to represent the changes.

Hope that's all okay. Let me know if there's anything you'd like me to do differently, or change. Thanks for looking. 👍