### PR TITLE
add README and vim help docs for <Plug> mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ A `word` (lowercase) is any of the following:
 A `WORD` (uppercase) is any sequence of non-space characters separated by
 spaces.
 
-Customization
-=============
+Customizing mappings
+====================
 
 Default `word`/`WORD` mappings:
 
@@ -56,8 +56,10 @@ Default `word`/`WORD` mappings:
 | `xo`  | `iw`/`iW`                 |
 | `c`   | `<C-R><C-W>`/`<C-R><C-A>` |
 
-Use `g:wordmotion_prefix` to apply a common prefix to each of the default word
-motion mappings.  
+There are three ways to customize these mappings:
+
+**(1) Use `g:wordmotion_prefix` to apply a common prefix to each of the default word
+motion mappings.** 
 E.g.,
 ```
 let g:wordmotion_prefix = '<Leader>'
@@ -65,8 +67,8 @@ let g:wordmotion_prefix = '<Leader>'
 NOTE: does not apply to the command line mode `<C-R><C-W>` and `<C-R><C-A>`
 mappings.
 
-Use `g:wordmotion_mappings` to individually replace the default word motion
-mappings.  
+**(2) Use `g:wordmotion_mappings` to individually replace the default word motion
+mappings.** 
 E.g.,
 ```
 let g:wordmotion_mappings = {
@@ -84,6 +86,25 @@ Set the value to an empty string to disable the mapping.
 
 NOTE: this overrides `g:wordmotion_prefix`.
 
+**(3) Use `<Plug>` mappings.**
+
+All available functionality is exposed through `<Plug>` mappings. If you use
+`<Plug>` mappings, you probably want to prevent wordmotion from defining any of
+the default bindings, which you can do by setting
+`g:wordmotion_disable_default_mappings = 1`.
+
+`<Plug>` mappings are defined according to this schema:
+```
+<Plug>WordMotion_MOTION/TEXTOBJ
+```
+
+For instance, `<Plug>WordMotion_w` is defined for modes `nxo`,
+`<Plug>WordMotion_aW` is defined for modes `xo`, and
+`<Plug>WordMotion_<C-R><C-W>` is defined for command mode.
+
+Customizing word definition
+===========================
+
 Use `g:wordmotion_spaces` (default `'_'`) to designate extra space characters.  
 E.g.,
 ```
@@ -94,6 +115,9 @@ will produce the following result:
 foo_bar-baz.qux
 w-->w-->w-->w>w
 ```
+
+Reloading
+=========
 
 All options can be applied dynamically by reloading the plugin.  
 E.g., to disable the `w` mapping:

--- a/doc/wordmotion.txt
+++ b/doc/wordmotion.txt
@@ -32,67 +32,80 @@ A `WORD` is any sequence of non-space characters separated by spaces.
 
 MAPPINGS					*wordmotion-mappings*
 
+By default, wordmotion overwrites Vim's built-in word motions. Set
+|g:wordmotion_prefix| to instead map wordmotion's commands to
+`{prefix}<MOTION>`. Alternatively, you can disable all default mappings by
+setting |g:wordmotion_disable_default_mappings| to 1, and define your own
+mappings against the |<Plug>| targets wordmotion provides. These are of the
+form |<Plug>WordMotion_MOTION|.
+
 						*wordmotion-w*
 {prefix}w		[count] `word`s forward. |exclusive| motion.
+<Plug>WordMotion_w
 
 						*wordmotion-e*
 {prefix}e		Forward to the end of `word` [count] |inclusive|.
-			Does not stop in an empty line.
+<Plug>WordMotion_e	Does not stop in an empty line.
 
 						*wordmotion-b*
 {prefix}b		[count] `word`s backward. |exclusive| motion.
+<Plug>WordMotion_b
 
 						*wordmotion-ge*
 {prefix}ge		Backward to the end of `word` [count] |inclusive|.
+<Plug>WordMotion_ge
 
 						*wordmotion-aw*
 a{prefix}w		"a `word`", select [count] `word`s (see |wordmotion-word|).
-			Leading or trailing white space is included, but not
+<Plug>WordMotion_aw	Leading or trailing white space is included, but not
 			counted.
 			When used in Visual linewise mode "aw" switches to
 			Visual characterwise mode.
 
 						*wordmotion-iw*
 i{prefix}w		"inner `word`", select [count] `word`s
-			(see |wordmotion-word|).
+<Plug>WordMotion_iw	(see |wordmotion-word|).
 			White space between `word`s is counted too.
 			When used in Visual linewise mode "iw" switches to
 			Visual characterwise mode.
 
 						*wordmotion-c_<C-R>_<C-W>*
-CTRL-R CTRL-W		Insert the `word` under the cursor
-			(see |wordmotion-word|).
+CTRL-R CTRL-W		        Insert the `word` under the cursor
+<Plug>WordMotion_<C-R><C-W>	(see |wordmotion-word|).
 
 						*wordmotion-W*
 {prefix}W		[count] `WORD`s forward. |exclusive| motion.
+<Plug>WordMotion_W
 
 						*wordmotion-E*
 {prefix}E		Forward to the end of `WORD` [count] |inclusive|.
-			Does not stop in an empty line.
+<Plug>WordMotion_E	Does not stop in an empty line.
 
 						*wordmotion-B*
 {prefix}B		[count] `WORD`s backward. |exclusive| motion.
+<Plug>WordMotion_B
 
 						*wordmotion-gE*
 {prefix}gE		Backward to the end of `WORD` [count] |inclusive|.
+<Plug>WordMotion_gE
 
 						*wordmotion-aW*
 a{prefix}W		"a `WORD`", select [count] `WORD`s (see |wordmotion-word|).
-			Leading or trailing white space is included, but not
+<Plug>WordMotion_aW	Leading or trailing white space is included, but not
 			counted.
 			When used in Visual linewise mode "aW" switches to
 			Visual characterwise mode.
 
 						*wordmotion-iW*
 i{prefix}W		"inner `WORD`", select [count] `WORD`s
-			(see |wordmotion-word|).
+<Plug>WordMotion_iW	(see |wordmotion-word|).
 			White space between `WORD`s is counted too.
 			When used in Visual linewise mode "iW" switches to
 			Visual characterwise mode.
 
 						*wordmotion-c_<C-R>_<C-A>*
-<C-R><C-A>		Insert the `WORD` under the cursor
-			(see |wordmotion-word|).
+<C-R><C-A>		        Insert the `WORD` under the cursor
+<Plug>WordMotion_<C-R><C-A>	(see |wordmotion-word|).
 
 CUSTOMIZATION					*wordmotion-customization*
 
@@ -129,6 +142,10 @@ Unspecified entries will still use the default mappings.
 Set the value to an empty string to disable the mapping.
 
 NOTE: this overrides |g:wordmotion_prefix|.
+
+						*g:wordmotion_disable_default_mappings*
+Set |g:wordmotion_disable_default_mappings = 1| to disable all default key
+mappings. This is useful if you want to use the |<Plug>| mappings.
 
 						*g:wordmotion_spaces*
 Use |g:wordmotion_spaces| (default '_') to designate extra space characters.


### PR DESCRIPTION
Thanks for adding the `<Plug>` functionality I requested. I noticed that you did not add docs so I went ahead and did so, for both the README and the Vim help.