### PR TITLE
Fix `cw` with count. Fixes #57.

### DIFF
--- a/autoload/wordmotion.vim
+++ b/autoload/wordmotion.vim
@@ -115,10 +115,12 @@ function wordmotion#motion(count, mode, flags, uppercase, extra)
 	let l:pos = getpos('.')
 
 	let l:count = a:count
+	if l:cw
+		" cw on the last character of a word will match the cursor position
+		call search('\m'.l:pattern, l:flags.'cW')
+		let l:count -= 1
+	endif
 	while l:count > 0
-		if l:count == 1 && l:cw
-			let l:flags .= 'c'
-		endif
 		call search('\m'.l:pattern, l:flags.'W')
 		let l:count -= 1
 	endwhile

--- a/tests/cw.vader
+++ b/tests/cw.vader
@@ -14,6 +14,15 @@ Then (Assert that cursor is at Tha[t]):
 Expect (This changed to That):
   That is some text
 
+Do (c2w at [T]his is):
+  c2wThat's\<Esc>
+
+Then (Assert that cursor is at That'[s]):
+  AssertEqual 6, col('.')
+
+Expect (This is changed to That's):
+  That's some text
+
 # first word of line, middle of word
 
 Do (cw at T[h]is):
@@ -26,6 +35,16 @@ Then (Assert that cursor is at TTha[t]):
 Expect (This changed to TThat):
   TThat is some text
 
+Do (c2w at T[h]is is):
+  l
+  c2wThat's\<Esc>
+
+Then (Assert that cursor is at TThat'[s]):
+  AssertEqual 7, col('.')
+
+Expect (This is changed to TThat's):
+  TThat's some text
+
 # first word of line, end of word
 
 Do (cw at Thi[s]):
@@ -37,6 +56,16 @@ Then (Assert that cursor is at ThiTha[t]):
 
 Expect (This changed to ThiThat):
   ThiThat is some text
+
+Do (c2w at Thi[s] is):
+  e
+  c2wThat's\<Esc>
+
+Then (Assert that cursor is at ThiThat'[s]):
+  AssertEqual 9, col('.')
+
+Expect (This is changed to ThiThat's):
+  ThiThat's some text
 
 # middle of line, start of word
 


### PR DESCRIPTION
It was only working without count or when the cursor was at the end of
the word.