### PR TITLE
Only match hex/octal/binary literals with word boundaries. Fixes #60.

### DIFF
--- a/autoload/wordmotion.vim
+++ b/autoload/wordmotion.vim
@@ -70,10 +70,10 @@ function wordmotion#init()
 	call add(l:words, l:u.'\+\ze'.l:u.l:l)       " ACRONYMSBeforeCamelCase
 	call add(l:words, l:u.'\+')                  " UPPERCASE
 	call add(l:words, l:l.'\+')                  " lowercase
-	call add(l:words, '#'.l:x.'\+')              " #0F0F0F
-	call add(l:words, '0[xX]'.l:x.'\+')          " 0x00 0Xff
-	call add(l:words, '0[oO][0-7]\+')            " 0o00 0O77
-	call add(l:words, '0[bB][01]\+')             " 0b00 0B11
+	call add(l:words, '#'.l:x.'\+\>')            " #0F0F0F
+	call add(l:words, '\<0[xX]'.l:x.'\+\>')      " 0x00 0Xff
+	call add(l:words, '\<0[oO][0-7]\+\>')        " 0o00 0O77
+	call add(l:words, '\<0[bB][01]\+\>')         " 0b00 0B11
 	call add(l:words, l:d.'\+')                  " 1234 5678
 	call add(l:words, l:_.C(l:p, l:a, s:s).'\+') " other printable characters
 	call add(l:words, '\%^')                     " start of file

--- a/tests/cpoptions.vader
+++ b/tests/cpoptions.vader
@@ -24,7 +24,6 @@ Execute (w with cpo-l):
 
 Execute (w with cpo-<):
   set cpoptions+=<
-  mapclear
   call wordmotion#reload()
   normal w
   AssertEqual 5, col('.')

--- a/tests/issues.vader
+++ b/tests/issues.vader
@@ -58,3 +58,20 @@ Do (Move over spaces):
 
 Then (Assert that cursor is at [b]ar):
   AssertEqual 'b', getline('.')[col('.') - 1]
+
+Given (#define: https://github.com/chaoren/vim-wordmotion/issues/60):
+  #define SCANCODE_TAB_KEY 15
+  123456789012345678901234567
+           1         2
+
+Do (Move 1 word):
+  w
+
+Then (Assert that cursor is at #[d]efine):
+  AssertEqual 2, col('.')
+
+Do (Move 3 word):
+  3w
+
+Then (Assert that cursor is at _[T]AB_):
+  AssertEqual 18, col('.')


### PR DESCRIPTION
The #def part of #define is not a hex literal.